### PR TITLE
In collections, these dependency roles cannot be resolve without relative path

### DIFF
--- a/roles/gui/cluster/meta/main.yml
+++ b/roles/gui/cluster/meta/main.yml
@@ -23,6 +23,6 @@ galaxy_info:
     - gui
 
 dependencies:
-  - core/common
+  - ../core/common
   - node
-  - zimon/cluster
+  - ../zimon/cluster

--- a/roles/gui/node/meta/main.yml
+++ b/roles/gui/node/meta/main.yml
@@ -23,7 +23,7 @@ galaxy_info:
     - gui
 
 dependencies:
-  - core/common
+  - ../core/common
   - precheck
-  - core/node
-  - zimon/node
+  - ../core/node
+  - ../zimon/node

--- a/roles/gui/precheck/meta/main.yml
+++ b/roles/gui/precheck/meta/main.yml
@@ -23,4 +23,4 @@ galaxy_info:
     - gui
 
 dependencies:
-  - core/common
+  - ../core/common

--- a/roles/zimon/cluster/meta/main.yml
+++ b/roles/zimon/cluster/meta/main.yml
@@ -24,4 +24,4 @@ galaxy_info:
     - zimon
 
 dependencies:
-  - core/common
+  - ../core/common

--- a/roles/zimon/node/meta/main.yml
+++ b/roles/zimon/node/meta/main.yml
@@ -23,5 +23,5 @@ galaxy_info:
     - gui
 
 dependencies:
-  - core/common
-  - core/node
+  - ../core/common
+  - ../core/node

--- a/roles/zimon/precheck/meta/main.yml
+++ b/roles/zimon/precheck/meta/main.yml
@@ -23,4 +23,4 @@ galaxy_info:
     - gui
 
 dependencies:
-  - core/common
+  - ../core/common


### PR DESCRIPTION
When running a playbook calling collections, with a directory structure like this

```
├── group_vars
│   └── all
├── hosts
├── playbook.yml
```

I am installing collections to relative path: `-p collections` 
When running: 

```
ERROR! the role 'core/common' was not found in ansible.legacy:/root/TEST/roles:/root/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/root/TEST/collections/ansible_collections/ibm_spectrum_scale/install_infra/roles/gui:/root/TEST

The error appears to be in '/root/TEST/collections/ansible_collections/ibm_spectrum_scale/install_infra/roles/gui/precheck/meta/main.yml': line 26, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

dependencies:
  - core/common
    ^ here
```

Changing `roles/gui/precheck/meta/main.yml` to be `../core/common` resolves it.
